### PR TITLE
Implement a key value repository with CRUD capabilities

### DIFF
--- a/KVS.UnitTest/GlobalUsings.cs
+++ b/KVS.UnitTest/GlobalUsings.cs
@@ -1,0 +1,1 @@
+global using NUnit.Framework;

--- a/KVS.UnitTest/KVS.UnitTests.csproj
+++ b/KVS.UnitTest/KVS.UnitTests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
@@ -16,7 +16,7 @@
     <PackageReference Include="NUnit.Analyzers" Version="3.6.1" />
     <PackageReference Include="coverlet.collector" Version="6.0.0" />
   </ItemGroup>
-    
+
   <ItemGroup>
       <ProjectReference Include="..\KVS\KVS.csproj" />
   </ItemGroup>

--- a/KVS.UnitTest/KVS.UnitTests.csproj
+++ b/KVS.UnitTest/KVS.UnitTests.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
+    <PackageReference Include="NUnit" Version="3.13.3" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
+    <PackageReference Include="NUnit.Analyzers" Version="3.6.1" />
+    <PackageReference Include="coverlet.collector" Version="6.0.0" />
+  </ItemGroup>
+    
+  <ItemGroup>
+      <ProjectReference Include="..\KVS\KVS.csproj" />
+  </ItemGroup>
+</Project>

--- a/KVS.UnitTest/KeyValueRepositoryTests.cs
+++ b/KVS.UnitTest/KeyValueRepositoryTests.cs
@@ -22,7 +22,6 @@ public sealed class KeyValueRepositoryTests
         Assert.That(success, Is.Not.Null);
 
         AssertRepositoryHasKeyValuePair(keyValueRepository, validKey, expectedValue);
-
     }
 
     [Test]
@@ -41,29 +40,33 @@ public sealed class KeyValueRepositoryTests
     }
 
     [Test]
-    public void RemoveByKey_ReturnsSuccess_WhenKeyIsPresent()
+    public void GetValueByKey_ReturnsSuccess_WithExpectedKey_WhenKeyIsPresent()
     {
         // Arrange
         const string presentKey = "present";
-        var keyValueRepository = new KeyValueRepository(new() { { presentKey, "" } });
+        const string expectedValue = "Value";
+        var keyValueRepository = new KeyValueRepository(new() { { presentKey, expectedValue } });
 
         // Act
-        var result = keyValueRepository.RemoveByKey(presentKey);
+        var result = keyValueRepository.GetValueByKey(presentKey);
 
         // Assert
-        var success = result.Value as Success?;
+        var success = result.Value as Success<string>?;
         Assert.That(success, Is.Not.Null);
+
+        var actualValue = success.Value.Value;
+        Assert.That(actualValue, Is.EqualTo(expectedValue));
     }
 
     [Test]
-    public void RemoveByKey_ReturnsNotFound_WhenKeyIsNotPresent()
+    public void GetValueByKey_ReturnsNotFound_WhenKeyIsNotPresent()
     {
         // Arrange
         const string notPresentKey = "notpresent";
         var keyValueRepository = new KeyValueRepository();
 
         // Act
-        var result = keyValueRepository.RemoveByKey(notPresentKey);
+        var result = keyValueRepository.GetValueByKey(notPresentKey);
 
         // Assert
         var notFound = result.Value as NotFound?;
@@ -97,6 +100,36 @@ public sealed class KeyValueRepositoryTests
 
         // Act
         var result = keyValueRepository.UpdateKeyValue(notPresentKey, "");
+
+        // Assert
+        var notFound = result.Value as NotFound?;
+        Assert.That(notFound, Is.Not.Null);
+    }
+
+    [Test]
+    public void RemoveByKey_ReturnsSuccess_WhenKeyIsPresent()
+    {
+        // Arrange
+        const string presentKey = "present";
+        var keyValueRepository = new KeyValueRepository(new() { { presentKey, "" } });
+
+        // Act
+        var result = keyValueRepository.RemoveByKey(presentKey);
+
+        // Assert
+        var success = result.Value as Success?;
+        Assert.That(success, Is.Not.Null);
+    }
+
+    [Test]
+    public void RemoveByKey_ReturnsNotFound_WhenKeyIsNotPresent()
+    {
+        // Arrange
+        const string notPresentKey = "notpresent";
+        var keyValueRepository = new KeyValueRepository();
+
+        // Act
+        var result = keyValueRepository.RemoveByKey(notPresentKey);
 
         // Assert
         var notFound = result.Value as NotFound?;

--- a/KVS.UnitTest/KeyValueRepositoryTests.cs
+++ b/KVS.UnitTest/KeyValueRepositoryTests.cs
@@ -40,4 +40,34 @@ public sealed class KeyValueRepositoryTests
         var alreadyPresentError = result.Value as AlreadyPresentError?;
         Assert.That(alreadyPresentError, Is.Not.Null);
     }
+
+    [Test]
+    public void RemoveByKey_ReturnsSuccess_WhenKeyIsPresent()
+    {
+        // Arrange
+        const string presentKey = "present";
+        var keyValueRepository = new KeyValueRepository(new() { { presentKey, "" } });
+
+        // Act
+        var result = keyValueRepository.RemoveByKey(presentKey);
+
+        // Assert
+        var success = result.Value as Success?;
+        Assert.That(success, Is.Not.Null);
+    }
+
+    [Test]
+    public void RemoveByKey_ReturnsNotFound_WhenKeyIsNotPresent()
+    {
+        // Arrange
+        const string notPresentKey = "notpresent";
+        var keyValueRepository = new KeyValueRepository();
+
+        // Act
+        var result = keyValueRepository.RemoveByKey(notPresentKey);
+
+        // Assert
+        var notFound = result.Value as NotFound?;
+        Assert.That(notFound, Is.Not.Null);
+    }
 }

--- a/KVS.UnitTest/KeyValueRepositoryTests.cs
+++ b/KVS.UnitTest/KeyValueRepositoryTests.cs
@@ -31,10 +31,9 @@ public sealed class KeyValueRepositoryTests
     {
         // Arrange
         const string duplicateKey = "Duplicate";
-        var keyValueRepository = new KeyValueRepository();
+        var keyValueRepository = new KeyValueRepository(new() { { duplicateKey, "" } });
 
         // Act
-        keyValueRepository.AddKeyValue(duplicateKey, "");
         var result = keyValueRepository.AddKeyValue(duplicateKey, "");
 
         // Assert

--- a/KVS.UnitTest/KeyValueRepositoryTests.cs
+++ b/KVS.UnitTest/KeyValueRepositoryTests.cs
@@ -21,9 +21,8 @@ public sealed class KeyValueRepositoryTests
         var success = result.Value as Success?;
         Assert.That(success, Is.Not.Null);
 
-        var hasKey = keyValueRepository.KeyValueCache.ContainsKey(validKey);
-        Assert.That(hasKey, Is.True);
-        Assert.That(keyValueRepository.KeyValueCache[validKey], Is.EqualTo(expectedValue));
+        AssertRepositoryHasKeyValuePair(keyValueRepository, validKey, expectedValue);
+
     }
 
     [Test]
@@ -69,5 +68,45 @@ public sealed class KeyValueRepositoryTests
         // Assert
         var notFound = result.Value as NotFound?;
         Assert.That(notFound, Is.Not.Null);
+    }
+
+    [Test]
+    public void UpdateKeyValue_ReturnsSuccess_WhenKeyIsPresent()
+    {
+        // Arrange
+        const string presentKey = "present";
+        const string expectedValue = "expected";
+        var keyValueRepository = new KeyValueRepository(new() { { presentKey, "" } });
+
+        // Act
+        var result = keyValueRepository.UpdateKeyValue(presentKey, expectedValue);
+
+        // Assert
+        var success = result.Value as Success?;
+        Assert.That(success, Is.Not.Null);
+
+        AssertRepositoryHasKeyValuePair(keyValueRepository, presentKey, expectedValue);
+    }
+
+    [Test]
+    public void UpdateKeyValue_ReturnsNotFound_WhenKeyIsNotPresent()
+    {
+        // Arrange
+        const string notPresentKey = "notpresent";
+        var keyValueRepository = new KeyValueRepository();
+
+        // Act
+        var result = keyValueRepository.UpdateKeyValue(notPresentKey, "");
+
+        // Assert
+        var notFound = result.Value as NotFound?;
+        Assert.That(notFound, Is.Not.Null);
+    }
+
+    static private void AssertRepositoryHasKeyValuePair(KeyValueRepository repo, string key, string expectedValue)
+    {
+        var hasKey = repo.KeyValueCache.ContainsKey(key);
+        Assert.That(hasKey, Is.True);
+        Assert.That(repo.KeyValueCache[key], Is.EqualTo(expectedValue));
     }
 }

--- a/KVS.UnitTest/KeyValueRepositoryTests.cs
+++ b/KVS.UnitTest/KeyValueRepositoryTests.cs
@@ -1,0 +1,44 @@
+using KVS.Errors;
+using KVS.Repositories;
+using OneOf.Types;
+
+namespace KVS.UnitTests;
+
+public sealed class KeyValueRepositoryTests
+{
+    [Test]
+    public void AddKeyValue_ReturnsSuccess_WhenKeyIsNotAlreadyPresent()
+    {
+        // Arrange
+        const string validKey = "Valid";
+        const string expectedValue = "Value";
+        var keyValueRepository = new KeyValueRepository();
+
+        // Act
+        var result = keyValueRepository.AddKeyValue(validKey, expectedValue);
+
+        // Assert
+        var success = result.Value as Success?;
+        Assert.That(success, Is.Not.Null);
+
+        var hasKey = keyValueRepository.KeyValueCache.ContainsKey(validKey);
+        Assert.That(hasKey, Is.True);
+        Assert.That(keyValueRepository.KeyValueCache[validKey], Is.EqualTo(expectedValue));
+    }
+
+    [Test]
+    public void AddKeyValue_ReturnsAlreadyPresent_WhenSameKeyIsAlreadyPresent()
+    {
+        // Arrange
+        const string duplicateKey = "Duplicate";
+        var keyValueRepository = new KeyValueRepository();
+
+        // Act
+        keyValueRepository.AddKeyValue(duplicateKey, "");
+        var result = keyValueRepository.AddKeyValue(duplicateKey, "");
+
+        // Assert
+        var alreadyPresentError = result.Value as AlreadyPresentError?;
+        Assert.That(alreadyPresentError, Is.Not.Null);
+    }
+}

--- a/KVS.sln
+++ b/KVS.sln
@@ -3,7 +3,9 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.8.34511.84
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "KVS", "KVS\KVS.csproj", "{3B3B4EB0-D59B-4399-B0EA-FF6396FAF07B}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "KVS", "KVS\KVS.csproj", "{3B3B4EB0-D59B-4399-B0EA-FF6396FAF07B}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "KVS.UnitTests", "KVS.UnitTest\KVS.UnitTests.csproj", "{671F734A-2493-4BC0-81F1-224E4B0BECDF}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -15,6 +17,10 @@ Global
 		{3B3B4EB0-D59B-4399-B0EA-FF6396FAF07B}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{3B3B4EB0-D59B-4399-B0EA-FF6396FAF07B}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{3B3B4EB0-D59B-4399-B0EA-FF6396FAF07B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{671F734A-2493-4BC0-81F1-224E4B0BECDF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{671F734A-2493-4BC0-81F1-224E4B0BECDF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{671F734A-2493-4BC0-81F1-224E4B0BECDF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{671F734A-2493-4BC0-81F1-224E4B0BECDF}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/KVS/Errors/AlreadyPresentError.cs
+++ b/KVS/Errors/AlreadyPresentError.cs
@@ -1,0 +1,5 @@
+﻿namespace KVS.Errors;
+
+public struct AlreadyPresentError
+{
+}

--- a/KVS/KVS.csproj
+++ b/KVS/KVS.csproj
@@ -12,6 +12,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.1" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.19.5" />
+    <PackageReference Include="OneOf" Version="3.0.263" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
   </ItemGroup>
 

--- a/KVS/Repositories/IKeyValueRepository.cs
+++ b/KVS/Repositories/IKeyValueRepository.cs
@@ -7,6 +7,7 @@ namespace KVS.Repositories;
 public interface IKeyValueRepository
 {
     public OneOf<Success, AlreadyPresentError> AddKeyValue(string key, string value);
+    public OneOf<Success<string>, NotFound> GetValueByKey(string key);
     public OneOf<Success, NotFound> UpdateKeyValue(string key, string newValue);
     public OneOf<Success, NotFound> RemoveByKey(string key);
 }

--- a/KVS/Repositories/IKeyValueRepository.cs
+++ b/KVS/Repositories/IKeyValueRepository.cs
@@ -7,5 +7,6 @@ namespace KVS.Repositories;
 public interface IKeyValueRepository
 {
     public OneOf<Success, AlreadyPresentError> AddKeyValue(string key, string value);
+    public OneOf<Success, NotFound> UpdateKeyValue(string key, string newValue);
     public OneOf<Success, NotFound> RemoveByKey(string key);
 }

--- a/KVS/Repositories/IKeyValueRepository.cs
+++ b/KVS/Repositories/IKeyValueRepository.cs
@@ -1,0 +1,10 @@
+﻿using KVS.Errors;
+using OneOf;
+using OneOf.Types;
+
+namespace KVS.Repositories;
+
+public interface IKeyValueRepository
+{
+    public OneOf<Success, AlreadyPresentError> AddKeyValue(string key, string value);
+}

--- a/KVS/Repositories/IKeyValueRepository.cs
+++ b/KVS/Repositories/IKeyValueRepository.cs
@@ -7,4 +7,5 @@ namespace KVS.Repositories;
 public interface IKeyValueRepository
 {
     public OneOf<Success, AlreadyPresentError> AddKeyValue(string key, string value);
+    public OneOf<Success, NotFound> RemoveByKey(string key);
 }

--- a/KVS/Repositories/KeyValueRepository.cs
+++ b/KVS/Repositories/KeyValueRepository.cs
@@ -6,6 +6,9 @@ namespace KVS.Repositories;
 
 public sealed class KeyValueRepository : IKeyValueRepository
 {
+    public KeyValueRepository() { }
+    public KeyValueRepository(Dictionary<string, string> initialKeyValues) => keyValueCache = initialKeyValues.ToDictionary();
+
     public OneOf<Success, AlreadyPresentError> AddKeyValue(string key, string value)
     {
         if (keyValueCache.TryAdd(key, value))

--- a/KVS/Repositories/KeyValueRepository.cs
+++ b/KVS/Repositories/KeyValueRepository.cs
@@ -19,6 +19,16 @@ public sealed class KeyValueRepository : IKeyValueRepository
         return new AlreadyPresentError();
     }
 
+    public OneOf<Success, NotFound> RemoveByKey(string key)
+    {
+        if (keyValueCache.Remove(key))
+        {
+            return new Success();
+        }
+
+        return new NotFound();  
+    }
+
     private readonly Dictionary<string, string> keyValueCache = [];
     public IReadOnlyDictionary<string, string> KeyValueCache
     {

--- a/KVS/Repositories/KeyValueRepository.cs
+++ b/KVS/Repositories/KeyValueRepository.cs
@@ -1,0 +1,24 @@
+﻿using KVS.Errors;
+using OneOf;
+using OneOf.Types;
+
+namespace KVS.Repositories;
+
+public sealed class KeyValueRepository : IKeyValueRepository
+{
+    public OneOf<Success, AlreadyPresentError> AddKeyValue(string key, string value)
+    {
+        if (keyValueCache.TryAdd(key, value))
+        {
+            return new Success();
+        }
+
+        return new AlreadyPresentError();
+    }
+
+    private readonly Dictionary<string, string> keyValueCache = [];
+    public IReadOnlyDictionary<string, string> KeyValueCache
+    {
+        get => keyValueCache.AsReadOnly();
+    }
+}

--- a/KVS/Repositories/KeyValueRepository.cs
+++ b/KVS/Repositories/KeyValueRepository.cs
@@ -19,6 +19,16 @@ public sealed class KeyValueRepository : IKeyValueRepository
         return new AlreadyPresentError();
     }
 
+    public OneOf<Success<string>, NotFound> GetValueByKey(string key)
+    {
+        if (keyValueCache.TryGetValue(key, out var value))
+        {
+            return new Success<string>(value);
+        }
+
+        return new NotFound();
+    }
+
     public OneOf<Success, NotFound> RemoveByKey(string key)
     {
         if (keyValueCache.Remove(key))

--- a/KVS/Repositories/KeyValueRepository.cs
+++ b/KVS/Repositories/KeyValueRepository.cs
@@ -29,6 +29,17 @@ public sealed class KeyValueRepository : IKeyValueRepository
         return new NotFound();  
     }
 
+    public OneOf<Success, NotFound> UpdateKeyValue(string key, string newValue)
+    {
+        if (keyValueCache.ContainsKey(key))
+        {
+            keyValueCache[key] = newValue;
+            return new Success();
+        }
+
+        return new NotFound();
+    }
+
     private readonly Dictionary<string, string> keyValueCache = [];
     public IReadOnlyDictionary<string, string> KeyValueCache
     {


### PR DESCRIPTION
We now have a key value repository that supports CRUD operations applied to it.

Currently, it only has an in-memory cache. However, we will add persistence along side the cache at a later point. 